### PR TITLE
Add reminder and recurrence support

### DIFF
--- a/src/main/java/com/example/todoist/TodoistApplication.java
+++ b/src/main/java/com/example/todoist/TodoistApplication.java
@@ -2,8 +2,10 @@ package com.example.todoist;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 
 public class TodoistApplication {
 

--- a/src/main/java/com/example/todoist/model/Due.java
+++ b/src/main/java/com/example/todoist/model/Due.java
@@ -31,4 +31,12 @@ public class Due implements Serializable {
     private Date datetime;
 
     private String timezone;
+
+    private boolean recurring;
+
+    private int recurrenceIntervalDays;
+
+    private boolean reminderEnabled;
+
+    private int reminderMinutesBefore;
 }

--- a/src/main/java/com/example/todoist/requestBean/DueRequest.java
+++ b/src/main/java/com/example/todoist/requestBean/DueRequest.java
@@ -21,4 +21,12 @@ public class DueRequest {
     private Date datetime;
 
     private String timezone;
+
+    private boolean recurring;
+
+    private int recurrenceIntervalDays;
+
+    private boolean reminderEnabled;
+
+    private int reminderMinutesBefore;
 }

--- a/src/main/java/com/example/todoist/serviceImplementer/ProjectServiceImplementer.java
+++ b/src/main/java/com/example/todoist/serviceImplementer/ProjectServiceImplementer.java
@@ -71,6 +71,10 @@ public class ProjectServiceImplementer implements ProjectService {
                         dueRequest.setDatetime(saveTask.getDue().getDatetime());
                         dueRequest.setString(saveTask.getDue().getString());
                         dueRequest.setTimezone(saveTask.getDue().getTimezone());
+                        dueRequest.setRecurring(saveTask.getDue().isRecurring());
+                        dueRequest.setRecurrenceIntervalDays(saveTask.getDue().getRecurrenceIntervalDays());
+                        dueRequest.setReminderEnabled(saveTask.getDue().isReminderEnabled());
+                        dueRequest.setReminderMinutesBefore(saveTask.getDue().getReminderMinutesBefore());
                     }
                     CreateTaskResponse createTaskResponse = CreateTaskResponse.builder()
                             .comment_count(saveTask.getCommentCount())
@@ -108,6 +112,10 @@ public class ProjectServiceImplementer implements ProjectService {
                     dueRequest.setDatetime(saveTask.getDue().getDatetime());
                     dueRequest.setString(saveTask.getDue().getString());
                     dueRequest.setTimezone(saveTask.getDue().getTimezone());
+                    dueRequest.setRecurring(saveTask.getDue().isRecurring());
+                    dueRequest.setRecurrenceIntervalDays(saveTask.getDue().getRecurrenceIntervalDays());
+                    dueRequest.setReminderEnabled(saveTask.getDue().isReminderEnabled());
+                    dueRequest.setReminderMinutesBefore(saveTask.getDue().getReminderMinutesBefore());
                 }
                 CreateTaskResponse createTaskResponse = CreateTaskResponse.builder()
                         .comment_count(saveTask.getCommentCount())

--- a/src/main/java/com/example/todoist/serviceImplementer/ReminderScheduler.java
+++ b/src/main/java/com/example/todoist/serviceImplementer/ReminderScheduler.java
@@ -1,0 +1,58 @@
+package com.example.todoist.serviceImplementer;
+
+import com.example.todoist.model.Due;
+import com.example.todoist.model.Task;
+import com.example.todoist.repository.DueRepository;
+import com.example.todoist.repository.TaskRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
+@Component
+public class ReminderScheduler {
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private DueRepository dueRepository;
+
+    @Scheduled(fixedRate = 60000)
+    public void sendReminders() {
+        Date now = new Date();
+        List<Task> tasks = taskRepository.findAll();
+        for (Task task : tasks) {
+            Due due = task.getDue();
+            if (due == null) {
+                continue;
+            }
+            Date dueTime = due.getDatetime() != null ? due.getDatetime() : due.getDate();
+            if (dueTime == null) {
+                continue;
+            }
+            long diffMinutes = (dueTime.getTime() - now.getTime()) / 60000;
+            if (due.isReminderEnabled() && diffMinutes <= due.getReminderMinutesBefore() && diffMinutes >= 0) {
+                log.info("Reminder: Task '{}' is due at {}", task.getContent(), dueTime);
+            }
+            if (due.isRecurring() && dueTime.before(now)) {
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(dueTime);
+                cal.add(Calendar.DATE, due.getRecurrenceIntervalDays());
+                Date newDue = cal.getTime();
+                if (due.getDatetime() != null) {
+                    due.setDatetime(newDue);
+                }
+                if (due.getDate() != null) {
+                    due.setDate(newDue);
+                }
+                dueRepository.save(due);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/todoist/serviceImplementer/TaskServiceImplementer.java
+++ b/src/main/java/com/example/todoist/serviceImplementer/TaskServiceImplementer.java
@@ -48,6 +48,10 @@ public class TaskServiceImplementer implements TaskService {
                     dueRequest.setDatetime(saveTask.getDue().getDatetime());
                     dueRequest.setString(saveTask.getDue().getString());
                     dueRequest.setTimezone(saveTask.getDue().getTimezone());
+                    dueRequest.setRecurring(saveTask.getDue().isRecurring());
+                    dueRequest.setRecurrenceIntervalDays(saveTask.getDue().getRecurrenceIntervalDays());
+                    dueRequest.setReminderEnabled(saveTask.getDue().isReminderEnabled());
+                    dueRequest.setReminderMinutesBefore(saveTask.getDue().getReminderMinutesBefore());
                 }
                 CreateTaskResponse createTaskResponse = CreateTaskResponse.builder()
                         .comment_count(saveTask.getCommentCount())
@@ -102,6 +106,10 @@ public class TaskServiceImplementer implements TaskService {
             due.setDate(taskRequest.getDue().getDate());
             due.setDatetime(taskRequest.getDue().getDatetime());
             due.setTimezone(taskRequest.getDue().getTimezone());
+            due.setRecurring(taskRequest.getDue().isRecurring());
+            due.setRecurrenceIntervalDays(taskRequest.getDue().getRecurrenceIntervalDays());
+            due.setReminderEnabled(taskRequest.getDue().isReminderEnabled());
+            due.setReminderMinutesBefore(taskRequest.getDue().getReminderMinutesBefore());
             dueRepository.save(due);
         }
         task.setDue(due);
@@ -127,6 +135,10 @@ public class TaskServiceImplementer implements TaskService {
             dueRequest.setDatetime(saveTask.getDue().getDatetime());
             dueRequest.setString(saveTask.getDue().getString());
             dueRequest.setTimezone(saveTask.getDue().getTimezone());
+            dueRequest.setRecurring(saveTask.getDue().isRecurring());
+            dueRequest.setRecurrenceIntervalDays(saveTask.getDue().getRecurrenceIntervalDays());
+            dueRequest.setReminderEnabled(saveTask.getDue().isReminderEnabled());
+            dueRequest.setReminderMinutesBefore(saveTask.getDue().getReminderMinutesBefore());
         }
         CreateTaskResponse createTaskResponse = CreateTaskResponse.builder()
                 .comment_count(saveTask.getCommentCount())
@@ -155,6 +167,10 @@ public class TaskServiceImplementer implements TaskService {
                 dueRequest.setDatetime(task.getDue().getDatetime());
                 dueRequest.setString(task.getDue().getString());
                 dueRequest.setTimezone(task.getDue().getTimezone());
+                dueRequest.setRecurring(task.getDue().isRecurring());
+                dueRequest.setRecurrenceIntervalDays(task.getDue().getRecurrenceIntervalDays());
+                dueRequest.setReminderEnabled(task.getDue().isReminderEnabled());
+                dueRequest.setReminderMinutesBefore(task.getDue().getReminderMinutesBefore());
             }
             CreateTaskResponse createTaskResponse = CreateTaskResponse.builder()
                     .comment_count(task.getCommentCount())
@@ -208,6 +224,10 @@ public class TaskServiceImplementer implements TaskService {
                 due.setDate(taskRequest.getDue().getDate());
                 due.setDatetime(taskRequest.getDue().getDatetime());
                 due.setTimezone(taskRequest.getDue().getTimezone());
+                due.setRecurring(taskRequest.getDue().isRecurring());
+                due.setRecurrenceIntervalDays(taskRequest.getDue().getRecurrenceIntervalDays());
+                due.setReminderEnabled(taskRequest.getDue().isReminderEnabled());
+                due.setReminderMinutesBefore(taskRequest.getDue().getReminderMinutesBefore());
                 dueRepository.save(due);
             }
             task.setDue(due);


### PR DESCRIPTION
## Summary
- extend `Due` entity with reminder and recurring task fields
- propagate new fields through request/response mappers
- add scheduled service to log reminders and handle recurrence
- enable scheduling in application

## Testing
- `sh ./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684b269e19648327be3d1edeedd0440c